### PR TITLE
había un y += que tenia que ser =

### DIFF
--- a/src/eletor/simulatenoise.py
+++ b/src/eletor/simulatenoise.py
@@ -93,7 +93,7 @@ def simulate_noise(control):
 
         #--- Create the synthetic noise
         #y += create_noise_(control,rng)
-        y += create_noise(m,dt,ms,noiseModels,rng)
+        y = create_noise(m,dt,ms,noiseModels,rng)
 
         #--- TODO: not always write mom files
         momwrite(y,t,dt,fname)


### PR DESCRIPTION
Era por motivos motivos históricos.