### PR TITLE
Test para simulate_noise con casos de hector.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/__pycache__
 .venv
 **/*.egg-info
+test/test_cases.toml

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,9 +1,59 @@
 import pytest
 
+import toml
+from pathlib import Path
+
+# Agregamos algunas opciones para casos específicos
 def pytest_addoption(parser):
+    # Algunos test basados en propiedades estadísticas pueden fallar
+    # al menos hasta que logre tunearlos. Con este flag se pueden activar, pero
+    # por defecto no se corren.
     parser.addoption("--stat_properties", action="store_true",
                      help="run the tests only in case of that command line (marked with marker @stat_properties)")
 
+    # Esta opción está por si en algún momento tenemos más de un archivo de
+    # tests para comparar con hector, que puede ser que sea uno más exhaustivo
+    # que el otro por ejemplo.
+    # De momento, dejando el default está bien.
+    parser.addoption(
+        "--hector_test_cases",
+        action="store",
+        default="test_cases.toml",
+        help="explicitly provide hector test cases file"
+    )
+
+# Este fixture es bobo, solamente para marcar que una función va a correr sobre
+# los test cases leidos desde el toml.
+@pytest.fixture()
+def hector_test_cases():
+    pass
+
+def pytest_generate_tests(metafunc):
+    # En caso de que un test pida los test cases
+    if "hector_test_cases" in metafunc.fixturenames:
+        # Pedimos el path al archivo de casos
+        filename = metafunc.config.getoption("hector_test_cases")
+
+        if not Path(filename).is_file():
+            pytest.skip(f"El archivo de casos {filename} no existe (se crea con create_test_cases.py)")
+
+        # Cargamos los casos
+        with open(filename,'r') as f:
+            casos = toml.load(f)
+
+        casos_list = []
+
+        for modelo,sub_casos in casos.items():
+            for etiqueta,parametros in sub_casos.items():
+                casos_list.append( (modelo,etiqueta,parametros) )
+
+        # Se parametriza la función con estos tres parámetros.
+        # (el tercero es el diccionario de opciones).
+        # Implicitamente, todo test que tenca hector_test_cases tiene que pedir
+        # también modelo, etiqueta, parámetros.
+        metafunc.parametrize("modelo, etiqueta, parametros", casos_list)
+
 def pytest_runtest_setup(item):
+    # Saltear por defauld los tests de stat_properties
     if 'stat_properties' in item.keywords and not item.config.getoption("--stat_properties"):
         pytest.skip("need --stat_properties option to run this test")

--- a/test/create_test_cases.py
+++ b/test/create_test_cases.py
@@ -48,6 +48,13 @@ def main(n):
 
             # Agregamos las opciones generales de configuración que hector
             # Si o Si necesita.
+
+            # Redondeamos el intervalo de tiempo para evitar
+            # errores de redondeo que después molesten a los test_cases.
+            dt = data['NoiseModels'][model][l]['dt']
+            dt = float(np.round(dt,5)) # a toml no le gustan numpy.float64
+            data['NoiseModels'][model][l]['dt'] = dt
+
             data['general'] = {}
             data['file_config'] = {}
             data['general']['NumberOfSimulations'] = 1

--- a/test/test_simulate_noise.py
+++ b/test/test_simulate_noise.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from hashlib import md5
 
 from eletor.simulatenoise import simulate_noise
+from eletor.compat import vector_to_mom
 
 #
 # Test de simulate_noise por casos
@@ -27,42 +28,33 @@ def test_simulate_noise_cases(hector_test_cases,modelo,etiqueta,parametros):
     # Agregar las opciones del modelo a testear
     data['NoiseModels'][modelo][etiqueta] = parametros
 
-    # Usamos un archivo temporal, asi se borra solo.
-    # El sufijo es importante porque por compatibilidad con
-    # hector siempre se agregaba ese sufijo.
-    with tempfile.NamedTemporaryFile(suffix='_0.mom') as f:
-        # Configuracion de archivo de salida para hector
-        fname = Path(f.name)
-        data['file_config']['SimulationLabel'] = fname.name.replace('_0.mom','')
-        data['file_config']['SimulationDir'] = str(fname.parent)
+    # Correr la simulación (devuelve lista, pero es sólo 1)
+    sim,*_ = simulate_noise(data)
 
-        # Correr la simulación
-        simulate_noise(data)
+    # Generar el Hash
+    md5hash = md5()
+    datalines = vector_to_mom(y=sim,sampling_period=parametros['dt'])
+    for line in datalines:
+        md5hash.update(line.encode())
 
-        # Generar el Hash
-        md5hash = md5()
-        with fname.open(mode='rb') as f:
-            bdata = f.read()
-            md5hash.update(bdata)
+    # En caso de que hubiera algún test que fallara y hubiera que
+    # revisar el mom directamente, había que hacer algo como:
+    # if md5hash.hexdigest() != parametros['md5']:
+    #   # Grabar la salida nuestra
+    #   with open('failed_test_{modelo}_{etiqueta}.mom','wb') as f:
+    #     f.write(bdata)
+    #
+    #   # Llamar al hector original
+    #   from call_old_hector import call_hector_with_toml
+    #   call_hector_with_toml(data,return_type='file')
+    #
+    #   # Copiar la salida de hector.
+    #   with fname.open(mode='rb') as f:
+    #     with open('hector_{modelo}_{etiqueta}.mom','wb') as f:
+    #       f.write(bdata)
+    # Esto queda comentado por la premisa de que nada que
+    # tenga que ver con hector tiene que quedar por default activo.
 
-        # En caso de que hubiera algún test que fallara y hubiera que
-        # revisar el mom directamente, había que hacer algo como:
-        # if md5hash.hexdigest() != parametros['md5']:
-        #   # Grabar la salida nuestra
-        #   with open('failed_test_{modelo}_{etiqueta}.mom','wb') as f:
-        #     f.write(bdata)
-        #
-        #   # Llamar al hector original
-        #   from call_old_hector import call_hector_with_toml
-        #   call_hector_with_toml(data,return_type='file')
-        #
-        #   # Copiar la salida de hector.
-        #   with fname.open(mode='rb') as f:
-        #     with open('hector_{modelo}_{etiqueta}.mom','wb') as f:
-        #       f.write(bdata)
-        # Esto queda comentado por la premisa de que nada que
-        # tenga que ver con hector tiene que quedar por default activo.
-
-        assert md5hash.hexdigest() == parametros['md5']
+    assert md5hash.hexdigest() == parametros['md5']
 
 

--- a/test/test_simulate_noise.py
+++ b/test/test_simulate_noise.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+import pytest
+
+import toml
+import tempfile
+
+from pathlib import Path
+from hashlib import md5
+
+from eletor.simulatenoise import simulate_noise
+
+#
+# Test de simulate_noise por casos
+#
+def test_simulate_noise_cases(hector_test_cases,modelo,etiqueta,parametros):
+    # Crear la estructura vacía de configuración
+    data = {'general':{},'file_config':{},'NoiseModels':{modelo:{}}}
+
+    # Opciones generales por defecto.
+    data['general']['NumberOfSimulations'] = 1
+    data['general']['TimeNoiseStart'] = 0
+    data['general']['NumberOfPoints'] = parametros['m']
+    data['general']['SamplingPeriod'] = parametros['dt']
+    data['general']['DeterministicNoise'] = True
+
+    # Agregar las opciones del modelo a testear
+    data['NoiseModels'][modelo][etiqueta] = parametros
+
+    # Usamos un archivo temporal, asi se borra solo.
+    # El sufijo es importante porque por compatibilidad con
+    # hector siempre se agregaba ese sufijo.
+    with tempfile.NamedTemporaryFile(suffix='_0.mom') as f:
+        # Configuracion de archivo de salida para hector
+        fname = Path(f.name)
+        data['file_config']['SimulationLabel'] = fname.name.replace('_0.mom','')
+        data['file_config']['SimulationDir'] = str(fname.parent)
+
+        # Correr la simulación
+        simulate_noise(data)
+
+        # Generar el Hash
+        md5hash = md5()
+        with fname.open(mode='rb') as f:
+            bdata = f.read()
+            md5hash.update(bdata)
+
+        # En caso de que hubiera algún test que fallara y hubiera que
+        # revisar el mom directamente, había que hacer algo como:
+        # if md5hash.hexdigest() != parametros['md5']:
+        #   # Grabar la salida nuestra
+        #   with open('failed_test_{modelo}_{etiqueta}.mom','wb') as f:
+        #     f.write(bdata)
+        #
+        #   # Llamar al hector original
+        #   from call_old_hector import call_hector_with_toml
+        #   call_hector_with_toml(data,return_type='file')
+        #
+        #   # Copiar la salida de hector.
+        #   with fname.open(mode='rb') as f:
+        #     with open('hector_{modelo}_{etiqueta}.mom','wb') as f:
+        #       f.write(bdata)
+        # Esto queda comentado por la premisa de que nada que
+        # tenga que ver con hector tiene que quedar por default activo.
+
+        assert md5hash.hexdigest() == parametros['md5']
+
+


### PR DESCRIPTION
El archivo de casos se genera corriendo create_test_cases.py

No lo subo al repo porque si después por algún motivo va cambiando es un toml de un montón de líneas que nos ensucia todo.

Las cosas que agregué en conftest.py siguen el esquema de la documentación de pytest para lograr que:

- Si se corren los tests y no existe test_cases.toml se saltean esos test.
- Si se corren los test con la opcion --hector_test_cases <archivo> se usa ese archivo como el de casos.
- Los casos leidos en el archivo .toml se crean un test individual para cada test que haya usado el fixture hector_test_cases
- Si se usa el fixture hector_test_cases hay que agregar al test los parámetros ```modelo, etiqueta, parametros```, que es la info que viene leida del toml.

Aparte de eso, dejé en el test una parte comentada que puede ser util si en algún momento es necesario comparar la salida completa de hector con nuestro código, no creo que la necesitemos nunca.